### PR TITLE
Handle whitespace properly

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -40,7 +40,9 @@
             "allow-leading-underscore",
             "allow-trailing-underscore",
             "allow-pascal-case"
-        ]
+        ],
+        "no-trailing-whitespace": true,
+        "whitespace": [true, "check-branch", "check-preblock", "check-decl", "check-type", "check-module"]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
I want things to look like this:

```
if(foo == bar){
 // do stuff
}
```
I do not want a space between the `if` and `(`. I do not want a space between `bar` and `)`. I definitely do not want a space between `)` and `{`.

I also don't know if this patch remedies that, but adding those spaces has IMO no benefits.

![hermanncrab-that-change-my-mind-meme-is-so-bad-its-31423483](https://user-images.githubusercontent.com/6482836/41025764-132cab08-6973-11e8-96d0-b5e4429dbb7a.png)
