### PR TITLE
PHP CodeStyle; ClassDeclaration.OpenBraceNewLine

### DIFF
--- a/phpcodesniffer.xml
+++ b/phpcodesniffer.xml
@@ -67,6 +67,7 @@
 		<exclude name="Generic.Commenting.DocComment"/>
 		<exclude name="Generic.Files.InlineHTML.Found"/>
 		<exclude name="Generic.Files.LowercasedFilename.NotFound"/>
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame"/>
 		<exclude name="Generic.PHP.ClosingPHPTag.NotFound"/>
 		<exclude name="Generic.PHP.UpperCaseConstant.Found"/>
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>

--- a/phpcodesniffer.xml
+++ b/phpcodesniffer.xml
@@ -6,7 +6,13 @@
 	<description>StudyPortals coding standard</description>
 
 	<rule ref="PSR1"/>
-	<rule ref="PSR2"/>
+	<rule ref="PSR2">
+		<exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
+		<exclude name="PSR2.Files.EndFileNewline.NoneFound"/>
+	</rule>
 	<rule ref="Squiz">
 		<exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
 		<exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
@@ -64,13 +70,24 @@
 	</rule>
 	<rule ref="Generic">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
 		<exclude name="Generic.Commenting.DocComment"/>
+		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
+		<exclude name="Generic.Files.EndFileNoNewline.Found"/>
 		<exclude name="Generic.Files.InlineHTML.Found"/>
 		<exclude name="Generic.Files.LowercasedFilename.NotFound"/>
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame"/>
+		<exclude name="Generic.Formatting.NoSpaceAfterCast.SpaceFound"/>
+		<exclude name="Generic.Formatting.SpaceAfterNot.Incorrect"/>
+		<exclude name="Generic.Functions.OpeningFunctionBraceBsdAllman.BraceOnSameLine"/>
+		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
 		<exclude name="Generic.PHP.ClosingPHPTag.NotFound"/>
 		<exclude name="Generic.PHP.UpperCaseConstant.Found"/>
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+
+		<exclude name="PEAR.ControlStructures.MultiLineCondition.SpaceBeforeOpenBrace"/>
+		<exclude name="PEAR.ControlStructures.MultiLineCondition.SpacingAfterOpenBrace"/>
+		<exclude name="PEAR.ControlStructures.MultiLineCondition.StartWithBoolean"/>
 		<exclude name="PEAR.Formatting.MultiLineAssignment.EqualSignLine"/>
 	</rule>
 </ruleset>

--- a/phpcodesniffer.xml
+++ b/phpcodesniffer.xml
@@ -6,12 +6,7 @@
 	<description>StudyPortals coding standard</description>
 
 	<rule ref="PSR1"/>
-	<rule ref="PSR2">
-		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT"/>
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
-	</rule>
+	<rule ref="PSR2"/>
 	<rule ref="Squiz">
 		<exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
 		<exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
@@ -69,22 +64,12 @@
 	</rule>
 	<rule ref="Generic">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
-		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
 		<exclude name="Generic.Commenting.DocComment"/>
 		<exclude name="Generic.Files.InlineHTML.Found"/>
 		<exclude name="Generic.Files.LowercasedFilename.NotFound"/>
-		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame"/>
-		<exclude name="Generic.Formatting.NoSpaceAfterCast.SpaceFound"/>
-		<exclude name="Generic.Formatting.SpaceAfterNot.Incorrect"/>
-		<exclude name="Generic.Functions.OpeningFunctionBraceBsdAllman.BraceOnSameLine"/>
-		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
 		<exclude name="Generic.PHP.ClosingPHPTag.NotFound"/>
 		<exclude name="Generic.PHP.UpperCaseConstant.Found"/>
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
-
-		<exclude name="PEAR.ControlStructures.MultiLineCondition.SpaceBeforeOpenBrace"/>
-		<exclude name="PEAR.ControlStructures.MultiLineCondition.SpacingAfterOpenBrace"/>
-		<exclude name="PEAR.ControlStructures.MultiLineCondition.StartWithBoolean"/>
 		<exclude name="PEAR.Formatting.MultiLineAssignment.EqualSignLine"/>
 	</rule>
 </ruleset>

--- a/phpcodesniffer.xml
+++ b/phpcodesniffer.xml
@@ -8,11 +8,9 @@
 	<rule ref="PSR1"/>
 	<rule ref="PSR2">
 		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
-		<exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT"/>
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
-		<exclude name="PSR2.Files.EndFileNewline.NoneFound"/>
 	</rule>
 	<rule ref="Squiz">
 		<exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>

--- a/phpcodesniffer.xml
+++ b/phpcodesniffer.xml
@@ -71,8 +71,6 @@
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
 		<exclude name="Generic.Commenting.DocComment"/>
-		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
-		<exclude name="Generic.Files.EndFileNoNewline.Found"/>
 		<exclude name="Generic.Files.InlineHTML.Found"/>
 		<exclude name="Generic.Files.LowercasedFilename.NotFound"/>
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame"/>


### PR DESCRIPTION
Quite some rules are excluded at the moment. It is possible to write code in different formats because of this, leading to a less readable document.

For instance
```php
class ClassA {
}
```
and
```php
class ClassB
{
}
```
are both considered to be correct and will be committed to GitHub in a mixed state. This change makes sure that only the second is allowed (and fixed automatically). This only counts for Class declarations so not for functions.