### PR TITLE
Do not enforce comments since the Code itself should be self explanatory.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,13 +29,6 @@ engines:
       standard: "phpcodesniffer.xml"
       ignore_warnings: false
       encoding: utf-8
-    checks:
-      Squiz Commenting ClassComment Missing:
-        enabled: false
-      Squiz Commenting VariableComment Missing:
-        enabled: false
-      Squiz Commenting FunctionComment Missing:
-        enabled: false
   phpmd:
     enabled: true
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,6 +29,13 @@ engines:
       standard: "phpcodesniffer.xml"
       ignore_warnings: false
       encoding: utf-8
+    checks:
+      Squiz Commenting ClassComment Missing:
+        enabled: false
+      Squiz Commenting VariableComment Missing:
+        enabled: false
+      Squiz Commenting FunctionComment Missing:
+        enabled: false
   phpmd:
     enabled: true
     config:

--- a/phpcodesniffer.xml
+++ b/phpcodesniffer.xml
@@ -22,18 +22,25 @@
 		<exclude name="Squiz.Commenting.BlockComment.FirstLineIndent"/>
 		<exclude name="Squiz.Commenting.BlockComment.LastLineIndent"/>
 		<exclude name="Squiz.Commenting.BlockComment.LineIndent"/>
+		<exclude name="Squiz.Commenting.BlockComment.SingleLine"/>
+		<exclude name="Squiz.Commenting.BlockComment.WrongStart"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
 		<exclude name="Squiz.Commenting.ClassComment.SpacingAfter"/>
 		<exclude name="Squiz.Commenting.ClosingDeclarationComment.Missing"/>
 		<exclude name="Squiz.Commenting.FileComment"/>
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
+		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfter"/>
 		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
 		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
+		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
+		<exclude name="Squiz.Commenting.InlineComment.DocBlock"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="Squiz.Commenting.InlineComment.SpacingAfter"/>
 		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
+		<exclude name="Squiz.Commenting.VariableComment.Missing"/>
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis"/>
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword"/>
@@ -64,10 +71,6 @@
 		<exclude name="Squiz.WhiteSpace.FunctionSpacing.AfterLast"/>
 		<exclude name="Squiz.WhiteSpace.FunctionSpacing.Before"/>
 		<exclude name="Squiz.WhiteSpace.OperatorSpacing.SpacingAfter"/>
-		<exclude name="Squiz.Commenting.InlineComment.DocBlock"/>
-		<exclude name="Squiz.Commenting.BlockComment.WrongStart"/>
-		<exclude name="Squiz.Commenting.BlockComment.SingleLine"/>
-		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
 	</rule>
 	<rule ref="Generic">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>


### PR DESCRIPTION
Enforcing comments will pollute the codebase with a lot of comments which do not bring any additional value. These comments tend to get out of sync and the developer tends to get blind for all these comments...

It's better to write a descriptive and type-strict code (Clean Code) and only add comments as last resort when you don't have another option. This way the comments will point out and the developer will read them.

> Nothing can be quite so helpful as a well-placed comment. Nothing can clutter up a module more than frivolous dogmatic comments. Nothing can be quite so damaging as an old crufty comment that propagates lies and misinformation.

– Clean Code; Chapter 4: Comments
_https://www.oreilly.com/library/view/clean-code/9780136083238/_