### PR TITLE
Small proposal to allow for better es6 support.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
         "browser": true
     },
     "parserOptions": {
-        "sourceType": "module"
+        "sourceType": "module",
+	    "ecmaVersion": 2017
     },
     "globals": {
     	"$": true,
@@ -21,4 +22,4 @@ module.exports = {
         "no-console": "off",
         "no-mixed-spaces-and-tabs": ["error", "smart-tabs"]
     }
-}
+};

--- a/tslint.json
+++ b/tslint.json
@@ -42,7 +42,8 @@
             "allow-pascal-case"
         ],
         "no-trailing-whitespace": true,
-        "whitespace": [true, "check-branch", "check-preblock", "check-decl", "check-type", "check-module"]
+        "whitespace": [true, "check-branch", "check-preblock", "check-decl", "check-type", "check-module"],
+        "no-namespace": [true, "allow-declarations"]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
ecmaVersion 2017 to allow for the async keyword in shorthand function declarations.
allow-declarations in no-namespace to allow for namespace declarations in *.d.ts files.

Also see https://codeclimate.com/repos/5b643fa5d57f8c0c980021bc/pull/684# for the `ecmaVersion 2017` rule 