### PR TITLE
Updated linting so it allows selector formats defined in SMACSS

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -16,8 +16,8 @@ linters:
   SelectorFormat:
     enabled: true
     allow_leading_underscore: false
-    convention: ^[A-Z][a-zA-Z]*$
-    convention_explanation: "UpperCamelCase"
+    convention: ^[a-zA-Z]*-?[a-zA-Z]*$
+    convention_explanation: "SMACSS compliance"
     element_convention: ^[a-zA-Z]+\d?$
     element_convention_explanation: "Only letters allowed"
     id_convention: ^[a-zA-Z]+$

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studyportals/code-style",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Default CodeClimate configurations for the Studyportals repositories",
 	"main": ".eslintrc.js",
 	"scripts": {


### PR DESCRIPTION
Why?: Enforcing only upper camel case selectors doesn't comply with SMACCS conventions. An example of this are state classes (.-active etc.) or JS hooks (.js-toolTip).