### PR TITLE
Remove deprecated variables from codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,7 +6,7 @@ prepare:
   - "https://raw.githubusercontent.com/studyportals/CodeStyle/master/.eslintignore"
   - "https://raw.githubusercontent.com/studyportals/CodeStyle/master/.eslintrc.js"
   - "https://raw.githubusercontent.com/studyportals/CodeStyle/master/tslint.json"
-engines:
+plugins:
   duplication:
     enabled: true
     config:
@@ -39,11 +39,5 @@ engines:
       rulesets: "phpmd.xml"
   scss-lint:
     enabled: true
-ratings:
-  paths:
-    - "**.php"
-    - "**.scss"
-    - "**.js"
-    - "**.ts"
-exclude_paths:
+exclude_patterns:
    - "**/vendor/"


### PR DESCRIPTION
To fix following warnings:

```
codeclimate validate-config
WARNING: 'engines' has been deprecated, please use 'plugins' instead
WARNING: 'exclude_paths' has been deprecated, please use 'exclude_patterns' instead
WARNING: 'ratings' has been deprecated, and will not be used
```