### PR TITLE
Add scroll snap additional properties

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -82,3 +82,8 @@ linters:
     enabled: true
     leading_underscore: false
     filename_extension: false
+
+  PropertySpelling:
+    extra_properties:
+        - scroll-snap-type
+        - scroll-snap-align


### PR DESCRIPTION
As South Park we are using the Scroll Snap properties on the BNW page, but CC does not like them as they are relatively new. This adds the properties we are using.
