### PR TITLE
Add "relaxed" phpcs-ruleset for use with *really* old CMS code

### DIFF
--- a/phpcs-relaxed.xml
+++ b/phpcs-relaxed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset name="StudyPortals Relaxed" namespace="StudyPortals\CS\Relaxed">
+
+  <rule ref="./phpcodesniffer.xml"/>
+
+	<!-- PSR2 -->
+	<rule ref="PSR2.Methods.FunctionCallSignature">
+		<type>warning</type>
+	</rule>
+
+	<!-- Generic -->
+  <rule ref="Generic.WhiteSpace.ScopeIndent">
+		<type>warning</type>
+	</rule>
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<type>warning</type>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
Running our proper `phpcs`-ruleset over the **_really_** old CMS code effectively underlines the
entire file in red &ndash; not very useful.

The aim of this more "relaxed" ruleset is to leave the most relevant sniffs in place, but remove most of the noise (either by lowering its severity to "warning" or by simply hiding it). It's setup up as an extension of the main ruleset (so any changes there will also apply to this ruleset, unless explicitly modified/excluded).

This is not intended for use with CodeClimate (that should remain as strict as ever), purely for (my personal? 😉) enjoyment during local developments on the old CMS code.