### PR TITLE
Update linting rules: no-shadow rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,8 +204,8 @@ overrides: [{
         "no-fallthrough": "error",
         "no-invalid-this": "off",
         "no-new-wrappers": "error",
-	"no-shadow": "off",
-	"@typescript-eslint/no-shadow": [
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": [
             "error",
             {
                 "hoist": "all"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,7 +204,8 @@ overrides: [{
         "no-fallthrough": "error",
         "no-invalid-this": "off",
         "no-new-wrappers": "error",
-        "no-shadow": [
+	"no-shadow": "off",
+	"@typescript-eslint/no-shadow": [
             "error",
             {
                 "hoist": "all"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/code-style",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studyportals/code-style",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Default linting configurations for the Studyportals repositories",
 	"main": ".eslintrc.js",
 	"scripts": {


### PR DESCRIPTION
## Story
https://studyportals.atlassian.net/browse/TBL-255

## What was done in this pull request?
This PR changes the linting configuration so that the following linting issue should not occur anymore:
```
<enum-name> is already declared in the upper scope on line <number> column <number>
```

## Reference
https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope

## Keywords
`no shadow` - `enums` - `linter`