### PR TITLE
Update linting rules: scss / styling-related action points. 

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,15 +6,14 @@
         "color-no-invalid-hex": true,
         "number-leading-zero": "always",
         "function-parentheses-space-inside": "never",
-        "block-closing-brace-space-after": "never",
         "shorthand-property-no-redundant-values": true,
-        "rule-empty-line-before": true,
+        "rule-empty-line-before": "always",
         "block-opening-brace-newline-after": "always",
         "block-closing-brace-newline-after": "always",
         "no-missing-end-of-source-newline": true,
         "color-hex-case": "upper",
         "selector-list-comma-newline-after" : "always",
-        "no-duplicate-at-import-rules" : "true",
+        "no-duplicate-at-import-rules" : true,
         "comment-no-empty" : true
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/code-style",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studyportals/code-style",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "Default linting configurations for the Studyportals repositories",
 	"main": ".eslintrc.js",
 	"scripts": {


### PR DESCRIPTION
## Story
https://studyportals.atlassian.net/browse/TBL-255

## What was done in this pull request?
This PR changes the linting configuration so that the following linting issue should not occur anymore:
```
Unexpected whitespace after "}"   block-closing-brace-space-after
```
```
Invalid Option: Unexpected option value "true" for rule "no-duplicate-at-import-rules"
```
```
Invalid Option: Invalid option value "true" for rule "rule-empty-line-before“
```

## References
https://stylelint.io/user-guide/rules/list/block-closing-brace-space-after/
https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rule
https://stylelint.io/user-guide/rules/list/rule-empty-line-before

## Related pull requests
https://github.com/studyportals/StudentMatchingTool-Clients/pull/10

## Keywords
`styling` - `scss` - `linter`